### PR TITLE
adds clap CLI interface

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,4 +1,4 @@
-name: Check cargo build and test work
+name: Rust checks
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +104,12 @@ checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -105,15 +148,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+
+[[package]]
 name = "oxysite"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert-str",
+ "clap",
  "env_logger",
  "log",
  "pulldown-cmark",
  "walkdir",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -126,6 +215,15 @@ dependencies = [
  "getopts",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -155,6 +253,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +286,12 @@ checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ log = "0.4"
 pulldown-cmark = "0.9.2"
 env_logger = "0.9.0"
 assert-str = "0.1.0"
+clap = { version = "4.0.26", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,53 @@
 
 A static site generator in Rust.
 
+## Installation
+
+This library is not available on [crates.io](https://crates.io/) and can only be installed directly from source using [cargo](https://crates.io/crates/cargo).
+
+### `cargo install` directly
+
+Install this library directly as a compiled executable in your `$HOME/.cargo/bin`.
+
+```bash
+$ git clone https://github.com/Sparrow0hawk/oxysite.git
+
+$ cargo install --path .
+
+$ oxysite --help
+Usage: oxysite <COMMAND>
+
+Commands:
+  build  Build site
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help information
+  -V, --version  Print version information
+```
+
+### Build and run within the repository
+
+If you'd rather not build the executable and add it to your path, you can build and run `oxysite` within the repository using `cargo`.
+
+```bash
+$ git clone https://github.com/Sparrow0hawk/oxysite.git
+
+# build as unoptimised
+$ cargo build
+
+# to build the test example
+$ cargo run -- build -c test_content -p magic
+```
+
+## Usage
+
+You can use this package to build `.html` files from `.md`. 
+Nothing particularly fancy out of the box but you would use it like this:
+
+```bash
+$ oxysite build -c markdown_files -p html_output
+```
+
+This command will build a HTML file for every markdown file in the `markdown_files` directory and write them into `html_output` directory (creating such a directory if it doesn't exist).
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ mod test {
     fn test_write_html() {
         let file = "test_content/home.md";
         let test_site = Site {
-            content_dir: String::from("test_content"),
+            content_dir: String::from("test_content/"),
             build_dir: String::from("public"),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,41 @@
 mod templates;
+use clap::{Parser, Subcommand};
 use oxysite::{rebuild_site, Site};
 
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Build site
+    Build {
+        /// Directory containing markdown files
+        #[arg(short = 'c', long)]
+        content: Option<String>,
+        /// Directory to write html files
+        #[arg(short = 'p', long)]
+        public: Option<String>,
+    },
+}
+
 fn main() -> Result<(), anyhow::Error> {
-    let content: String = String::from("test_content");
-    let public: String = String::from("public");
+    let cli = Cli::parse();
 
-    let config = Site {
-        content_dir: content,
-        build_dir: public,
-    };
+    match cli.command {
+        Commands::Build { content, public } => {
+            let config = Site {
+                content_dir: content.unwrap(),
+                build_dir: public.unwrap(),
+            };
 
-    rebuild_site(config);
+            let _ = rebuild_site(config);
+        }
+    }
 
     // rebuild_site(&str, &str)
     // delete public dir


### PR DESCRIPTION
This PR adds a CLI interface for `oxysite` using clap. This is through a `build` subcommand.

This PR also fixes a bug where adding a trailing slash to the content directory led to HTML files being created in the working directory with the `public` directory argument appended to the filename.